### PR TITLE
feat: Fluent plugin configuration, documentation and pt_BR translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,38 +1,28 @@
-# Filament plugin to add renew password on panel
+# Filament Renew Password Plugin
 
-This plugin permits to ask user to renew their password according to the last renew or other criteria.
+The Filament Renew Password Plugin enhances Filament by prompting users to renew their passwords based on specified criteria.
 
-## Install
+![Screenshot](https://raw.githubusercontent.com/yebor974/filament-renew-password/main/docs/screenshots/screenshot_1.png)
 
-You can install the package via composer command:
+## Installation
+
+1. Install the package using the composer command:
 
 ```bash
 composer require yebor974/filament-renew-password
 ```
 
-Publish associated vendor and launch migration. This adds new column `last-renew-password-at` in users table.
+2. Publish the associated vendor files and run the migration, which adds a new column `last_renew_password_at` to the users table.
 
-```php
+```bash
 php artisan vendor:publish
 php artisan migrate
 ```
 
-## Usage 
+Alternatively, if you don't want to publish the migrations or already have a column in your database for such case, you can skip this step and customize the column name by using any of the configuration methods described in the [Configuration](#configuration) section below.
 
-First, implement `RenewPasswordContract` on your Authenticate Model (User) and define criteria for asking renew password on `needRenewPassword` function
+3. Register the plugin in your panel provider:
 
-Example for each 90 days :
-```php
-public function needRenewPassword(): bool
-{
-    return Carbon::parse($this->last_renew_password_at ?? $this->created_at)->addDays(90) < now();
-}
-```
-
-You can also use default Trait `RenewPassword` and customize the period in days with env named `FILAMENT_RENEW_PASSWORD_DAYS_PERIOD`
-By default, it's configured for 90 days.
-
-Next, register the plugin in your Filament's Panel :
 ```php
 use Yebor974\Filament\RenewPassword\RenewPasswordPlugin;
 
@@ -43,7 +33,61 @@ public function panel(Panel $panel): Panel
 }
 ```
 
-And enjoy ! :)
+## Configuration
+Filament Renew Password Plugin is designed to work out of the box with minimal configuration. However, you can customize the plugin by publishing the configuration file, changing the environment variables or using the plugin object to override the default settings.
 
-![Screenshot](https://raw.githubusercontent.com/yebor974/filament-renew-password/main/docs/screenshots/screenshot_1.png)
+### Via Plugin Configuration
+```php
 
+// app/Providers/Filament/YourPanelServiceProvider.php
+
+RenewPasswordPlugin::make()
+    ->timestampColumn('password_changed_at')
+    ->passwordExpiresIn(days: 30)
+```
+
+### Via Environment Variables
+```env
+// .env
+
+FILAMENT_RENEW_PASSWORD_DAYS_PERIOD=30
+FILAMENT_RENEW_PASSWORD_TIMESTAMP_COLUMN=last_renew_password_at
+```
+
+### Via Configuration File
+```php
+// config/filament-renew-password.php
+
+return [
+    'timestamp_column' => 'password_changed_at',
+    'password_expires_in' => 30,
+];
+```
+
+Any of the above methods will work. The plugin will use the configuration in the following order of priority: Plugin Configuration, Environment Variables, Configuration File.
+
+## Usage
+
+### Implementing the `RenewPasswordContract` Contract
+
+1. Implement the `RenewPasswordContract` on your Authentication Model (User) and define the criteria for prompting password renewal in the `needRenewPassword` function.
+
+> Example for a 90-day renewal period:
+```php
+
+class User extends Authenticatable implements RenewPasswordContract
+{
+    ... 
+    
+    public function needRenewPassword(): bool
+    {
+        return Carbon::parse($this->last_renew_password_at ?? $this->created_at)->addDays(90) < now();
+    }
+}
+```
+
+### Using the `RenewPassword` Trait
+
+1. Alternatively, you can use the `RenewPassword` trait on your Authentication Model (User). By default, the trait uses the configured column and a 90-day renewal period. You can customize the column name and renewal period by [configuring the plugin](#configuration).
+
+Enjoy ! :)

--- a/README.md
+++ b/README.md
@@ -68,8 +68,6 @@ Any of the above methods will work. The plugin will use the configuration in the
 
 ## Usage
 
-### Implementing the `RenewPasswordContract` Contract
-
 1. Implement the `RenewPasswordContract` on your Authentication Model (User) and define the criteria for prompting password renewal in the `needRenewPassword` function.
 
 > Example for a 90-day renewal period:
@@ -86,8 +84,13 @@ class User extends Authenticatable implements RenewPasswordContract
 }
 ```
 
-### Using the `RenewPassword` Trait
+Alternatively, you can use the `RenewPassword` trait on your Authentication Model (User). By default, the trait uses the configured column and a 90-day renewal period. You can customize the column name and renewal period by [configuring the plugin](#configuration).
 
-1. Alternatively, you can use the `RenewPassword` trait on your Authentication Model (User). By default, the trait uses the configured column and a 90-day renewal period. You can customize the column name and renewal period by [configuring the plugin](#configuration).
+```php
+class User extends Authenticatable implements RenewPasswordContract
+{
+    use RenewPassword;
+}
+```
 
 Enjoy ! :)

--- a/config/filament-renew-password.php
+++ b/config/filament-renew-password.php
@@ -1,5 +1,7 @@
 <?php
 
 return [
-    'renew_password_days_period' => env('FILAMENT_RENEW_PASSWORD_DAYS_PERIOD', 90)
+    'renew_password_days_period' => env('FILAMENT_RENEW_PASSWORD_DAYS_PERIOD', 90),
+
+    'renew_password_timestamp_column' => env('FILAMENT_RENEW_PASSWORD_TIMESTAMP_COLUMN', 'last_renew_password_at'),
 ];

--- a/database/migrations/add_renew_password_on_users_table.php
+++ b/database/migrations/add_renew_password_on_users_table.php
@@ -10,14 +10,14 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('users', function (Blueprint $table) {
-            $table->timestamp('last_renew_password_at')->nullable();
+            $table->timestamp(config('filament-renew-password.renew_password_timestamp_column'))->nullable();
         });
     }
 
     public function down(): void
     {
         Schema::table('users', function (Blueprint $table) {
-            $table->dropColumn('last_renew_password_at');
+            $table->dropColumn(config('filament-renew-password.renew_password_timestamp_column'));
         });
     }
 

--- a/resources/lang/pt_BR/renew-password.php
+++ b/resources/lang/pt_BR/renew-password.php
@@ -1,0 +1,26 @@
+<?php
+
+return [
+    'title' => 'Renovar senha',
+    'heading' => 'É hora de renovar sua senha para garantir a segurança da sua conta.',
+    'form' => [
+        'current-password' => [
+            'label' => 'Senha atual'
+        ],
+        'password' => [
+            'label' => 'Nova senha'
+        ],
+        'password-confirmation' => [
+            'label' => 'Confirmação da nova senha'
+        ],
+        'actions' => [
+            'renew' => [
+                'label' => 'Renovar'
+            ]
+        ]
+    ],
+    'notifications' => [
+        'title' => 'Renovar Senha',
+        'body' => 'Senha renovada com sucesso!'
+    ]
+];

--- a/src/Middleware/RenewPasswordMiddleware.php
+++ b/src/Middleware/RenewPasswordMiddleware.php
@@ -7,7 +7,6 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Redirect;
 use Illuminate\Support\Facades\URL;
 use Yebor974\Filament\RenewPassword\Contracts\RenewPasswordContract;
-use Yebor974\Filament\RenewPassword\Traits\RenewPassword as RenewPasswordTrait;
 
 class RenewPasswordMiddleware
 {
@@ -19,11 +18,9 @@ class RenewPasswordMiddleware
         $user = $request->user();
 
         if (
-            $user && 
-            (
-                in_array(RenewPasswordContract::class, class_implements($user)) ||
-                in_array(RenewPasswordTrait::class, class_uses($user))
-            ) && $user->needRenewPassword()
+            $user 
+            && in_array(RenewPasswordContract::class, class_implements($user))
+            && $user->needRenewPassword()
         ) {
             $panel ??= Filament::getCurrentPanel()->getId();
 

--- a/src/Middleware/RenewPasswordMiddleware.php
+++ b/src/Middleware/RenewPasswordMiddleware.php
@@ -7,6 +7,7 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Redirect;
 use Illuminate\Support\Facades\URL;
 use Yebor974\Filament\RenewPassword\Contracts\RenewPasswordContract;
+use Yebor974\Filament\RenewPassword\Traits\RenewPassword as RenewPasswordTrait;
 
 class RenewPasswordMiddleware
 {
@@ -15,7 +16,15 @@ class RenewPasswordMiddleware
      */
     public function handle(Request $request, \Closure $next): mixed
     {
-        if ($request->user() && in_array(RenewPasswordContract::class, class_implements($request->user())) && $request->user()->needRenewPassword()) {
+        $user = $request->user();
+
+        if (
+            $user && 
+            (
+                in_array(RenewPasswordContract::class, class_implements($user)) ||
+                in_array(RenewPasswordTrait::class, class_uses($user))
+            ) && $user->needRenewPassword()
+        ) {
             $panel ??= Filament::getCurrentPanel()->getId();
 
             return Redirect::guest(URL::route("filament.{$panel}.auth.password.renew"));

--- a/src/Middleware/RenewPasswordMiddleware.php
+++ b/src/Middleware/RenewPasswordMiddleware.php
@@ -15,6 +15,7 @@ class RenewPasswordMiddleware
      */
     public function handle(Request $request, \Closure $next): mixed
     {
+        /** @var RenewPasswordContract $user */
         $user = $request->user();
 
         if (

--- a/src/Pages/Auth/RenewPassword.php
+++ b/src/Pages/Auth/RenewPassword.php
@@ -14,7 +14,6 @@ use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Validation\Rules\Password as PasswordRule;
 use Yebor974\Filament\RenewPassword\Contracts\RenewPasswordContract;
-use Yebor974\Filament\RenewPassword\Traits\RenewPassword as RenewPasswordTrait;
 use Yebor974\Filament\RenewPassword\RenewPasswordPlugin;
 
 class RenewPassword extends SimplePage

--- a/src/Pages/Auth/RenewPassword.php
+++ b/src/Pages/Auth/RenewPassword.php
@@ -38,11 +38,8 @@ class RenewPassword extends SimplePage
         $user = Filament::auth()->user();
 
         if(
-            $user &&
-            (
-                !in_array(RenewPasswordContract::class, class_implements($user)) &&
-                !in_array(RenewPasswordTrait::class, class_uses($user))
-            ) || !$user->needRenewPassword()
+            ! in_array(RenewPasswordContract::class, class_implements($user))
+            || !$user->needRenewPassword()
         ) {
             redirect()->intended(Filament::getUrl());
         }

--- a/src/RenewPasswordPlugin.php
+++ b/src/RenewPasswordPlugin.php
@@ -8,10 +8,13 @@ use Yebor974\Filament\RenewPassword\Middleware\RenewPasswordMiddleware;
 
 class RenewPasswordPlugin implements Plugin
 {
+    protected ?int $passwordExpiresIn = null;
+
+    protected ?string $timestampColumn = null;
 
     public function getId(): string
     {
-        return 'Renew Password';
+        return 'filament-renew-password';
     }
 
     public function register(Panel $panel): void
@@ -21,11 +24,46 @@ class RenewPasswordPlugin implements Plugin
 
     public function boot(Panel $panel): void
     {
-        //
+        if(! $this->getPasswordExpiresIn()) {
+            $this->passwordExpiresIn(config('filament-renew-password.renew_password_days_period'));
+        }
+
+        if(! $this->getTimestampColumn()) {
+            $this->timestampColumn(config('filament-renew-password.renew_password_timestamp_column'));
+        }
+    }
+
+    public function passwordExpiresIn(int $days): static
+    {
+        $this->passwordExpiresIn = $days;
+
+        return $this;
+    }
+
+    public function getPasswordExpiresIn(): ?int
+    {
+        return $this->passwordExpiresIn;
+    }
+
+    public function timestampColumn(string $column): static
+    {
+        $this->timestampColumn = $column;
+
+        return $this;
+    }
+
+    public function getTimestampColumn(): string
+    {
+        return $this->timestampColumn;
     }
 
     public static function make(): static
     {
         return app(static::class);
+    }
+
+    public static function get(): static
+    {
+        return filament(app(static::class)->getId());
     }
 }

--- a/src/Traits/RenewPassword.php
+++ b/src/Traits/RenewPassword.php
@@ -3,13 +3,14 @@
 namespace Yebor974\Filament\RenewPassword\Traits;
 
 use Carbon\Carbon;
+use Yebor974\Filament\RenewPassword\RenewPasswordPlugin;
 
 trait RenewPassword
 {
-
     public function needRenewPassword(): bool
     {
-        return Carbon::parse($this->last_renew_password_at ?? $this->created_at)->addDays(config('filament-renew-password.renew_password_days_period')) < now();
-    }
+        $plugin = RenewPasswordPlugin::get();
 
+        return Carbon::parse($this->{$plugin->getTimestampColumn()} ?? $this->created_at)->addDays($plugin->getPasswordExpiresIn()) < now();
+    }
 }


### PR DESCRIPTION
Hey! Thanks for the time you've invested in making this plugin. I was ready to make my own when i saw yours and decided to contribute.

This PR adds:

- pt_BR language
- Improved docs
- Configuration via the Plugin class
   We can now configure the plugin using the Plugin class without the needing to publish config/ migrations.
   
    ```php
    RenewPasswordPlugin::make()
        ->timestampColumn('password_changed_at')
        ->passwordExpiresIn(days: 30)
    ```