### PR TITLE
Fix RenewPasswordMiddleware.php by bypassing the logout route of Filament panel

### DIFF
--- a/src/Middleware/RenewPasswordMiddleware.php
+++ b/src/Middleware/RenewPasswordMiddleware.php
@@ -15,6 +15,9 @@ class RenewPasswordMiddleware
      */
     public function handle(Request $request, \Closure $next): mixed
     {
+        if($request->routeIs(Filament::getCurrentPanel()->generateRouteName('auth.logout')))
+            return $next($request);
+
         /** @var RenewPasswordContract $user */
         $user = $request->user();
 


### PR DESCRIPTION
#4 fix on RenewPasswordMiddleware