### PR TITLE
Correct nullable type

### DIFF
--- a/src/RenewPasswordPlugin.php
+++ b/src/RenewPasswordPlugin.php
@@ -59,7 +59,7 @@ class RenewPasswordPlugin implements Plugin
         return $this->timestampColumn;
     }
 
-    public function passwordExpiresIn(int $days = null): static
+    public function passwordExpiresIn(?int $days = null): static
     {
         $this->passwordExpiresIn = $days;
         if(!$this->timestampColumn) {


### PR DESCRIPTION
Implicitly nullable parameter types are now deprecated in PHP 8.4

```
Yebor974\Filament\RenewPassword\RenewPasswordPlugin::passwordExpiresIn(): Implicitly marking parameter $days as nullable is deprecated, the explicit nullable type must be used instead in /var/www/html/vendor/yebor974/filament-renew-password/src/RenewPasswordPlugin.php on line 62
```