### PR TITLE
Check if there is a user

### DIFF
--- a/src/Pages/Auth/RenewPassword.php
+++ b/src/Pages/Auth/RenewPassword.php
@@ -38,7 +38,7 @@ class RenewPassword extends SimplePage
 
     public function mount(): void
     {
-        /** @var RenewPasswordContract $user */
+        /** @var RenewPasswordContract|null $user */
         $user = Filament::auth()->user();
 
         if (

--- a/src/Pages/Auth/RenewPassword.php
+++ b/src/Pages/Auth/RenewPassword.php
@@ -42,7 +42,8 @@ class RenewPassword extends SimplePage
         $user = Filament::auth()->user();
 
         if (
-            ! in_array(RenewPasswordContract::class, class_implements($user))
+            ! $user
+            || ! in_array(RenewPasswordContract::class, class_implements($user))
             || ! $user->needRenewPassword()
         ) {
             $this->redirectIntended(Filament::getUrl());


### PR DESCRIPTION
Currently when a guest tries to visit /dashboard/password/renew an error occurs:

class_implements(): Argument #1 ($object_or_class) must be of type object|string, null given ... at ... /vendor/yebor974/filament-renew-password/src/Pages/Auth/RenewPassword.php:45